### PR TITLE
devcontainer: Add `expo-cli` and `prettier`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,9 @@
 {
 	"name": "Node.js & TypeScript",
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+	"features": {
+		"ghcr.io/devcontainers-extra/features/expo-cli:1": {},
+		"ghcr.io/devcontainers-extra/features/prettier:1": {}
+	},
 	"postCreateCommand": "npm install"
 }


### PR DESCRIPTION
The `expo-cli` is used for the development of the React Native application and `prettier` is used as the code formatter for Typescript.

Closed #4.